### PR TITLE
read a VInt instead of just a single byte

### DIFF
--- a/header.go
+++ b/header.go
@@ -137,8 +137,6 @@ func (r *Reader) readMetadata() error {
 }
 
 func (r *Reader) readString() (string, error) {
-	r.clear()
-
 	length, err := ReadVInt(r.reader)
 	if err != nil {
 		return "", err

--- a/header.go
+++ b/header.go
@@ -138,14 +138,14 @@ func (r *Reader) readMetadata() error {
 
 func (r *Reader) readString() (string, error) {
 	r.clear()
-	b, err := r.consume(1)
+
+	length, err := ReadVInt(r.reader)
 	if err != nil {
 		return "", err
 	}
 
-	length := int(b[0])
 	r.clear()
-	b, err = r.consume(length)
+	b, err := r.consume(int(length))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
According to sequencefile docs, the header is written out using
Text.writeString[0](https://wiki.apache.org/hadoop/SequenceFile#SeqFileHeader), which uses a VInt as the length of the string to
read[1](https://hadoop.apache.org/docs/current/api/src-html/org/apache/hadoop/io/Text.html#line.479)
